### PR TITLE
Sync updates from internal public branch

### DIFF
--- a/.github/workflows/push-to-public.yml
+++ b/.github/workflows/push-to-public.yml
@@ -46,9 +46,18 @@ jobs:
         run: |
           git push public-repo updates
 
-      # the PR is on the public hello-gator repo, so we need to figure out how to get permissions
+      - name: Fetch all branches
+        run: git fetch --all
 
-#      - name: Create Pull Request
-#        run: |
-#          gh auth login --with-token <<< "${{ secrets.GITHUB_TOKEN }}"
-#          gh pr create --base public --head updates --repo MetaMask/hello-gator --title "Sync updates from internal public branch" --body "This PR syncs the public branch with the latest changes from the internal repository."
+      - name: Create local branches
+        run: |
+          git checkout -b main origin/main
+
+      - name: Create changelog
+        run: |
+          git log --merges --oneline main ^public --pretty=format:"-%s: %b" > changelog.txt
+
+      - name: Create Pull Request
+        run: |
+          gh auth login --with-token <<< "${{ secrets.PR_TOKEN }}"
+          gh pr create --base main --head updates --repo MetaMask/hello-gator --title "Sync updates from internal public branch" --body "$(cat changelog.txt)"


### PR DESCRIPTION
-Merge pull request #21 from MetaMask/feat/multi-signer-support: Adds support for Burner EOA, Injected provider, and web3auth
-Merge pull request #19 from MetaMask/fix/gas-fee: Add gas fee resolver.
-Merge pull request #17 from MetaMask/feat/disable_buttons: Disable buttons when they aren't able to perform their function.
-Merge pull request #14 from MetaMask/chore/new-sdk: Update to use delegator-core-viem 0.1.1
-Merge pull request #13 from MetaMask/fix/rm-wagmi-example: Remove Wagmi example (and some Viem example sprucing)
-Merge pull request #11 from MetaMask/feat/tweaking-viem-demo: Fleshing out the viem demo
-Merge pull request #9 from MetaMask/chore/auth-token-env: chore: adding the registry auth token to env + address vercel build issue
-Merge pull request #7 from MetaMask/chore/tidying: Various tidying
-Merge pull request #3 from MetaMask/sdk-troubleshooting: Support for delegations
-Merge branch 'main' into sdk-troubleshooting: 
-Merge pull request #2 from MetaMask/sdk-troubleshooting: chore: tweaking the page flow + adding jiffyscan link
-Merge pull request #1 from MetaMask/sdk-troubleshooting: Sdk troubleshooting